### PR TITLE
Use RMarkdown to create bibliography overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ papers
 *.fdb_latexmk
 *.fls
 # code output
-index.html
+*.html
 public
+.Rproj.user

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,14 @@
-dist: trusty
-language: r
-sudo: true
-latex: false
+language: python
+python:
+  - "3.8"
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y python3.8
+  - sudo apt-get install -y r-base:4.0.3
+  - sudo apt-get install -y r-cran-data.table r-cran-tidyverse
 install:
   - pip install --user -r requirements.txt
+  - Rscript -e "installOrQuit(c('pacman', 'here', 'DT'))"
 script:
   - make
-cache: packages
-r_packages:
-  - pacman
-  - here
-  - data.table
-  - DT
-  - tidyverse
-os:
-  - linux
 deploy:
   # Use Github pages deploy process
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y python3
 install:
-  - pip install -r requirements.txt
+  - pip install --upgrade pip
+  - pip install bibtexparser
+  - pip install pandas
 # command to run tests
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python:
   - "3.8"
 before_install:
-  - sudo apt-get install -y r-base:4.0.3
+  - sudo apt-get update
+  - sudo apt-get install -y r-base
   - sudo apt-get install -y r-cran-data.table r-cran-tidyverse
 install:
   - pip install --user -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: xenial
 language: r
 sudo: true
+latex: false
 before_install:
   - sudo apt-get install python3 python3-pip python3-pandas python3-setuptools
   - pip3 install bibtexparser

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: r
 sudo: true
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y python3
 install:
-  - sudo apt-get install -y python3.7
   - pip install -r requirements.txt
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
-language: python
-python:
-  - "3.8"
+dist: xenial
+language: r
+sudo: true
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y r-base
-  - sudo apt-get install -y r-cran-data.table r-cran-tidyverse
-install:
-  - pip install --user -r requirements.txt
-  - Rscript -e "installOrQuit(c('pacman', 'here', 'DT'))"
+  - sudo apt-get install python3 python3-pip python3-pandas
+  - pip3 install bibtexparser
+# command to run tests
 script:
   - make
+cache: packages
+r_packages:
+  - pacman
+  - here
+  - data.table
+  - DT
+  - tidyverse
 deploy:
   # Use Github pages deploy process
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
-language: python
-python:
-  - "3.8"
+language: r
 install:
+  - sudo apt-get install -y python3.8
   - pip install -r requirements.txt
 # command to run tests
 script:
-  - python3 code/parser.py
-
+  - make
+cache: packages
+r_packages:
+  - pacman
+  - here
+  - data.table
+  - DT
+  - tidyverse
+os:
+  - linux
 deploy:
   # Use Github pages deploy process
   provider: pages
@@ -20,6 +27,6 @@ deploy:
   keep-history: true
   # Git branch on which it should deploy (master, gh-pages, foo...)
   target_branch: gh-pages
-  on:
-    # Which branch on commit/push will trigger deployment
-    branch: master
+#  on:
+#    # Which branch on commit/push will trigger deployment
+#    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: r
 sudo: true
 before_install:
-  - sudo apt-get install python3 python3-pip python3-pandas
+  - sudo apt-get install python3 python3-pip python3-pandas python3-setuptools
   - pip3 install bibtexparser
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-dist: xenial
+dist: trusty
 language: r
 sudo: true
+latex: false
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y python3.8
 install:
   - pip install --user -r requirements.txt
-# command to run tests
 script:
   - make
 cache: packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y python3
 install:
-  - pip install --upgrade pip
   - pip install bibtexparser
   - pip install pandas
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: r
+sudo: true
 install:
-  - sudo apt-get install -y python3.8
+  - sudo apt-get install -y python3.7
   - pip install -r requirements.txt
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
+dist: xenial
 language: r
 sudo: true
 before_install:
   - sudo apt-get update
-  - sudo apt-get install -y python3
+  - sudo apt-get install -y python3.8
 install:
-  - pip install bibtexparser
-  - pip install pandas
+  - pip install --user -r requirements.txt
 # command to run tests
 script:
   - make

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,6 @@
+Package: bibliography
+Title: bibliography
+Version: 0.0.1
+Imports: pacman, here, data.table, DT, tidyverse
+License: MIT
+Remotes: lnnrtwttkhn/bibliography

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,4 +3,3 @@ Title: bibliography
 Version: 0.0.1
 Imports: pacman, here, data.table, DT, tidyverse
 License: MIT
-Remotes: lnnrtwttkhn/bibliography

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+bibliography.Rmd: bibliography.csv
+	R -e "rmarkdown::render('code/bibliography.Rmd',output_file='../public/index.html')"
+
+bibliography.csv:
+	python3 code/parser.py

--- a/README.md
+++ b/README.md
@@ -133,3 +133,6 @@ The following links have helped me to create my own bibliography repo (thank you
 * ["Academics should ditch Elsevier and Mendeley — here’s how" - article by Steve Chignell on medium.com](https://medium.com/the-nature-of-food/academics-should-ditch-elsevier-and-mendeley-heres-how-153f1a8bf5f4)
 * ["Why you should not use Mendeley as a reference manager" - article on medium.com](https://medium.com/@gagarine/3-reasons-you-shouldn-t-use-mendeley-8f00d609bd12)
 * [Pandas dataframe to HTML using `pd.to_html()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_html.html)
+* [The `DT` R package](https://rstudio.github.io/DT)
+* [How to remove curly brackets in R](https://stackoverflow.com/questions/17528159/removing-curly-brackets-in-r)
+* [How to convert URL character strings into hyperlinks in DT tables in R](https://stackoverflow.com/questions/30901027/convert-a-column-of-text-urls-into-active-hyperlinks-in-shiny)

--- a/bibliography.Rproj
+++ b/bibliography.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: No
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Makefile

--- a/code/bibliography.Rmd
+++ b/code/bibliography.Rmd
@@ -28,9 +28,9 @@ path_bib <- here::here("public", "bibliography.csv")
 ```{r, echo=FALSE}
 bib <- data.table::fread(path_bib) %>%
   # turn URLs into hyperlinks that open in a new tap:
-  transform(url = paste0("<a href='", url , "' target='_blank'>URL</a>")) %>%
+  .[, url := paste0("<a href='", url , "' target='_blank'>URL</a>")] %>%
   # remove curly brackets from the title:
-  transform(title = gsub("[{}]", "", title))
+  .[, title := gsub("[{}]", "", title)]
 ```
 
 # Bibliography

--- a/code/bibliography.Rmd
+++ b/code/bibliography.Rmd
@@ -23,15 +23,23 @@ if (!requireNamespace("pacman")) install.packages("pacman")
 packages_cran <- c("here", "data.table", "DT", "tidyverse")
 pacman::p_load(char = packages_cran)
 path_bib <- here::here("public", "bibliography.csv")
+```
+
+```{r, echo=FALSE}
 bib <- data.table::fread(path_bib) %>%
-  select(-"author")
+  # turn URLs into hyperlinks that open in a new tap:
+  transform(url = paste0("<a href='", url , "' target='_blank'>URL</a>")) %>%
+  # remove curly brackets from the title:
+  transform(title = gsub("[{}]", "", title))
 ```
 
 # Bibliography
 
-```{r, echo=FALSE}
-DT::datatable(bib, class = "cell-border stripe", rownames = FALSE,
-              options = list(scrollX = TRUE)) 
+```{r}
+DT::datatable(
+  bib, class = "cell-border stripe", rownames = FALSE,
+  options = list(scrollX = TRUE), escape = FALSE,
+  ) 
 ```
 
 # Packages

--- a/code/bibliography.Rmd
+++ b/code/bibliography.Rmd
@@ -11,14 +11,14 @@ output:
     number_sections: true
     highlight: pygments
     theme: cosmo
-    code_folding: "show"
+    code_folding: "hide"
     df_print: paged
     fig_caption: true
 fig.align: "center"
 email: wittkuhn@mpib-berlin.mpg.de
 ---
 
-```{r, echo=FALSE, warning=FALSE, message=FALSE}
+```{r, warning=FALSE, message=FALSE, echo=FALSE}
 if (!requireNamespace("pacman")) install.packages("pacman")
 packages_cran <- c("here", "data.table", "DT", "tidyverse")
 pacman::p_load(char = packages_cran)
@@ -44,7 +44,7 @@ DT::datatable(
 
 # Packages
 
-```{r, echo=FALSE}
+```{r}
 sessionInfo()
 ```
 

--- a/code/bibliography.Rmd
+++ b/code/bibliography.Rmd
@@ -1,0 +1,43 @@
+---
+title: "Bibliography"
+author: "Lennart Wittkuhn"
+date: "Last update: `r format(Sys.time(), '%d %B, %Y')`"
+output:
+  html_document:
+    toc: yes
+    self_contained: true
+    toc_float: true
+    toc_depth: 3
+    number_sections: true
+    highlight: pygments
+    theme: cosmo
+    code_folding: "show"
+    df_print: paged
+    fig_caption: true
+fig.align: "center"
+email: wittkuhn@mpib-berlin.mpg.de
+---
+
+```{r, echo=FALSE, warning=FALSE, message=FALSE}
+if (!requireNamespace("pacman")) install.packages("pacman")
+packages_cran <- c("here", "data.table", "DT", "tidyverse")
+pacman::p_load(char = packages_cran)
+path_bib <- here::here("public", "bibliography.csv")
+bib <- data.table::fread(path_bib) %>%
+  select(-"author")
+```
+
+# Bibliography
+
+```{r, echo=FALSE}
+DT::datatable(bib, class = "cell-border stripe", rownames = FALSE,
+              options = list(scrollX = TRUE)) 
+```
+
+# Packages
+
+```{r, echo=FALSE}
+sessionInfo()
+```
+
+

--- a/code/parser.py
+++ b/code/parser.py
@@ -17,9 +17,9 @@ with open(os.path.join(path_code, 'bibliography.bib')) as bibtex_file:
 df = pd.DataFrame(bib_database.entries)
 df = df.filter(items=['ID', 'title', 'author', 'year', 'journal', 'url'])
 df = df.sort_values(by=['author', 'year', 'journal'])
-html = df.to_html(
-        render_links=True, index_names=False, bold_rows=False,
-        index=False)
+#html = df.to_html(
+#        render_links=True, index_names=False, bold_rows=False,
+#        index=False)
 csv_name = "bibliography.csv"
 csv_path = os.path.join(path_root, 'public', csv_name)
 df.to_csv(csv_path, index=False)

--- a/code/parser.py
+++ b/code/parser.py
@@ -23,8 +23,8 @@ html = df.to_html(
 csv_name = "bibliography.csv"
 csv_path = os.path.join(path_root, 'public', csv_name)
 df.to_csv(csv_path, index=False)
-html_name = "index.html"
-html_path = os.path.join(path_root, 'public', html_name)
-with open(html_path, "w") as html_file:
-    html_file.write(html)
-print('Created {} successfully!'.format(html_name))
+#html_name = "index.html"
+#html_path = os.path.join(path_root, 'public', html_name)
+#with open(html_path, "w") as html_file:
+#    html_file.write(html)
+#print('Created {} successfully!'.format(html_name))

--- a/code/parser.py
+++ b/code/parser.py
@@ -15,11 +15,14 @@ if not os.path.exists(os.path.join(path_root, 'public')):
 with open(os.path.join(path_code, 'bibliography.bib')) as bibtex_file:
     bib_database = bibtexparser.bparser.BibTexParser(common_strings=True).parse_file(bibtex_file)
 df = pd.DataFrame(bib_database.entries)
-df = df.filter(items=['title', 'author', 'year', 'journal', 'url'])
-df = df.sort_values(by=['author', 'year'])
+df = df.filter(items=['ID', 'title', 'author', 'year', 'journal', 'url'])
+df = df.sort_values(by=['author', 'year', 'journal'])
 html = df.to_html(
         render_links=True, index_names=False, bold_rows=False,
         index=False)
+csv_name = "bibliography.csv"
+csv_path = os.path.join(path_root, 'public', csv_name)
+df.to_csv(csv_path, index=False)
 html_name = "index.html"
 html_path = os.path.join(path_root, 'public', html_name)
 with open(html_path, "w") as html_file:


### PR DESCRIPTION
Until now, I used `df.to_html` in Python to create an html overview of the contents of `code/bibliography.bib`.

RMarkdown allows more options for customization and could be further used to create topic-specific tables, statistics etc.

After a fair bit of tweaking (see commit history) the build on travis was successful, hence this PR.